### PR TITLE
chore: add env property update

### DIFF
--- a/.bluemix/pipeline_helm.yml
+++ b/.bluemix/pipeline_helm.yml
@@ -320,6 +320,9 @@ stages:
   - name: CHART_ROOT
     type: text
     value: chart
+  - name: APP_URL
+    type: text
+    value: ""
   triggers:
   - type: stage
 - name: Verification

--- a/.bluemix/pipeline_knative.yml
+++ b/.bluemix/pipeline_knative.yml
@@ -281,6 +281,9 @@ stages:
   - name: SERVICE_FILE_UPDATE_INSTRUCTIONS_FILE
     type: text
     value: service_update_instructions.yaml
+  - name: APP_URL
+    type: text
+    value: ""
   triggers:
   - type: stage
 - name: Verification

--- a/README.md
+++ b/README.md
@@ -103,5 +103,5 @@ Note that for successful deployment, the application will need deployment assets
 
 1. Create a fork of the [skit assets repository](https://github.com/IBM/devex-skit-assets).
 1. In your forked repository, add your deployment assets to the `deployment-assets` folder inside of a folder named the same as the starter kit based on its GitHub URL. Follow the pattern set by the existing deployment assets.
-1. After creating an instance of the toolchain as described above, go to the configuration page for the Build stage of each pipeline and change the `DEVX_SKIT_ASSETS_GIT` environment property to point to your forked repository. Save your changes.
+1. After creating an instance of the toolchain as described above, go to the configuration page for the Build stage of each pipeline and change the `DEVX_SKIT_ASSETS_GIT` environment property to point to your forked repository, and the `DEVX_SKIT_ASSETS_GIT_RELEASE` to the latest version (Ex. Use 'v1.0.0'). Save your changes.
 1. Run the pipeline(s) and check that all stages succeed.


### PR DESCRIPTION
Without the proposed update to the `DEVX_SKIT_ASSETS_GET_RELEASE` the Build stage always fails:  
<img width="662" alt="Screen Shot 2020-09-03 at 4 34 28 PM" src="https://user-images.githubusercontent.com/19801489/92176454-1b171980-ee04-11ea-96bc-9f1b10f1e928.png">

<img width="701" alt="Screen Shot 2020-09-03 at 4 34 56 PM" src="https://user-images.githubusercontent.com/19801489/92176467-223e2780-ee04-11ea-8f82-a37c5e8147cd.png">

<img width="683" alt="Screen Shot 2020-09-03 at 4 40 52 PM" src="https://user-images.githubusercontent.com/19801489/92176542-439f1380-ee04-11ea-8cd2-3fb20764dbf5.png">
