### PR TITLE
4236-Add CRA scanning to skit monitoring pipelines

### DIFF
--- a/.bluemix/pipeline_tekton_cf.yml
+++ b/.bluemix/pipeline_tekton_cf.yml
@@ -20,6 +20,10 @@ inputs:
     service: ${TEKTON_CATALOG_REPO}
     branch: master
     path: toolchain
+  - type: git
+    service: ${TEKTON_CATALOG_REPO}
+    branch: master
+    path: cra
 triggers:
   - type: git
     name: commit-push

--- a/.bluemix/pipeline_tekton_helm.yml
+++ b/.bluemix/pipeline_tekton_helm.yml
@@ -40,6 +40,10 @@ inputs:
     branch: master
     service: ${TEKTON_CATALOG_REPO}
     path: utils
+  - type: git
+    service: ${TEKTON_CATALOG_REPO}
+    branch: master
+    path: cra
 triggers:
   - type: git
     name: commit-push

--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -225,6 +225,9 @@ services:
       pipeline_success: true
       pipeline_fail: true
 
+  devops-insights:
+      service_id: draservicebroker
+
 form:
   pipeline:
     parameters:

--- a/.pipeline/cf/listener.yaml
+++ b/.pipeline/cf/listener.yaml
@@ -36,6 +36,8 @@ spec:
     - name: DEPLOY_TARGET
       description: the deployment target
       default: "cf"
+    - name: APP_NAME
+      description: the name of the skit being monitored
     - name: SKIT_REG_ENDPOINT
       description: the skit registration endpoint URL
     - name: SKIT_REG_AUTH_TOKEN
@@ -111,6 +113,8 @@ spec:
             value: $(params.DEVX_SKIT_ASSETS_GIT_URL_RAW)
           - name: deploy-target
             value: $(params.DEPLOY_TARGET)
+          - name: skit-name
+            value: $(params.APP_NAME)
           - name: skit-reg-endpoint
             value: $(params.SKIT_REG_ENDPOINT)
           - name: skit-reg-auth-token

--- a/.pipeline/cf/listener.yaml
+++ b/.pipeline/cf/listener.yaml
@@ -36,7 +36,7 @@ spec:
     - name: DEPLOY_TARGET
       description: the deployment target
       default: "cf"
-    - name: APP_NAME
+    - name: app-name
       description: the name of the skit being monitored
     - name: SKIT_REG_ENDPOINT
       description: the skit registration endpoint URL
@@ -114,7 +114,7 @@ spec:
           - name: deploy-target
             value: $(params.DEPLOY_TARGET)
           - name: skit-name
-            value: $(params.APP_NAME)
+            value: $(params.app-name)
           - name: skit-reg-endpoint
             value: $(params.SKIT_REG_ENDPOINT)
           - name: skit-reg-auth-token

--- a/.pipeline/cf/listener.yaml
+++ b/.pipeline/cf/listener.yaml
@@ -36,7 +36,7 @@ spec:
     - name: DEPLOY_TARGET
       description: the deployment target
       default: "cf"
-    - name: app-name
+    - name: APP_NAME
       description: the name of the skit being monitored
     - name: SKIT_REG_ENDPOINT
       description: the skit registration endpoint URL
@@ -114,7 +114,7 @@ spec:
           - name: deploy-target
             value: $(params.DEPLOY_TARGET)
           - name: skit-name
-            value: $(params.app-name)
+            value: $(params.APP_NAME)
           - name: skit-reg-endpoint
             value: $(params.SKIT_REG_ENDPOINT)
           - name: skit-reg-auth-token

--- a/.pipeline/cf/pipeline.yaml
+++ b/.pipeline/cf/pipeline.yaml
@@ -186,7 +186,7 @@ spec:
         - name: commit-id
           value: $(tasks.skit-git-clone.results.git-commit)
         - name: directory-name
-          value: $(SKIT_NAME)
+          value: $(params.cf-app)
         - name: scm-type
           value: $(params.scm-type)
         - name: project-id

--- a/.pipeline/cf/pipeline.yaml
+++ b/.pipeline/cf/pipeline.yaml
@@ -34,6 +34,12 @@ spec:
       default: ""
     - name: git-url
       description: the repo URL of the skit repo
+    - name: pr-url
+      description: pr url
+    - name: commit-timestamp
+    - name: scm-type
+    - name: project-id
+      default: ""
     - name: devex-skit-assets-git
       description: the org and repo containing skit assets
     - name: devex-skit-assets-git-release
@@ -129,7 +135,7 @@ spec:
         - name: revision
           value: $(params.branch)
         - name: commit-id
-          value: $(tasks.clone-task.results.git-commit)
+          value: $(tasks.skit-git-clone.results.git-commit)
         - name: pipeline-debug
           value: $(params.pipeline-debug)
         - name: directory-name
@@ -154,7 +160,7 @@ spec:
         - name: pr-url
           value: $(params.pr-url)
         - name: commit-id
-          value: $(tasks.clone-task.results.git-commit)
+          value: $(tasks.skit-git-clone.results.git-commit)
         - name: scm-type
           value: $(params.scm-type)
         - name: project-id
@@ -177,7 +183,7 @@ spec:
         - name: pr-url
           value: $(params.pr-url)
         - name: commit-id
-          value: $(tasks.clone-task.results.git-commit)
+          value: $(tasks.skit-git-clone.results.git-commit)
         - name: directory-name
           value: ""
         - name: scm-type
@@ -202,11 +208,11 @@ spec:
         - name: pr-url
           value: $(params.pr-url)
         - name: commit-id
-          value: $(tasks.clone-task.results.git-commit)
+          value: $(tasks.skit-git-clone.results.git-commit)
         - name: target-branch
           value: $(params.branch)
         - name: target-commit-id
-          value: $(tasks.clone-task.results.git-commit)      
+          value: $(tasks.skit-git-clone.results.git-commit)      
         - name: scm-type
           value: $(params.scm-type)
         - name: project-id

--- a/.pipeline/cf/pipeline.yaml
+++ b/.pipeline/cf/pipeline.yaml
@@ -94,7 +94,7 @@ spec:
         - name: properties-file
           value: "build.properties"
         - name: directory-name
-          value: ""
+          value: "."
         - name: pipeline-debug
           value: $(params.pipeline-debug)
       workspaces:
@@ -117,7 +117,7 @@ spec:
         - name: properties-file
           value: ""
         - name: directory-name
-          value: $(params.cf-app)
+          value: "."
         - name: pipeline-debug
           value: $(params.pipeline-debug)
       workspaces:
@@ -140,7 +140,7 @@ spec:
         - name: pipeline-debug
           value: $(params.pipeline-debug)
         - name: directory-name
-          value: $(params.cf-app)
+          value: "."
         - name: commit-timestamp
           value: ""
     - name: code-vulnerability-scan

--- a/.pipeline/cf/pipeline.yaml
+++ b/.pipeline/cf/pipeline.yaml
@@ -220,8 +220,7 @@ spec:
         - name: project-id
           value: $(params.project-id)
     - name: build
-      runAfter:
-        - cra-discovery-scan
+      runAfter: [code-vulnerability-scan, cra-cis-check, cra-bom]
       workspaces:
         - name: output
           workspace: pipeline-ws

--- a/.pipeline/cf/pipeline.yaml
+++ b/.pipeline/cf/pipeline.yaml
@@ -118,7 +118,7 @@ spec:
         - name: properties-file
           value: ""
         - name: directory-name
-          value: $(params.skit-name)
+          value: ""
         - name: pipeline-debug
           value: $(params.pipeline-debug)
       workspaces:

--- a/.pipeline/cf/pipeline.yaml
+++ b/.pipeline/cf/pipeline.yaml
@@ -117,7 +117,7 @@ spec:
         - name: properties-file
           value: ""
         - name: directory-name
-          value: $(SKIT_NAME)
+          value: $(params.cf-app)
         - name: pipeline-debug
           value: $(params.pipeline-debug)
       workspaces:
@@ -140,7 +140,7 @@ spec:
         - name: pipeline-debug
           value: $(params.pipeline-debug)
         - name: directory-name
-          value: $(SKIT_NAME)
+          value: $(params.cf-app)
         - name: commit-timestamp
           value: ""
     - name: code-vulnerability-scan

--- a/.pipeline/cf/pipeline.yaml
+++ b/.pipeline/cf/pipeline.yaml
@@ -53,6 +53,7 @@ spec:
       description: the repo URL used to download skit asset raw code
     - name: deploy-target
       description: the deployment target
+    - name: skit-name
     - name: skit-reg-endpoint
     - name: skit-reg-auth-token
     - name: devx-slack-channel-webhook
@@ -94,7 +95,7 @@ spec:
         - name: properties-file
           value: "build.properties"
         - name: directory-name
-          value: "."
+          value: $(params.skit-name)
         - name: pipeline-debug
           value: $(params.pipeline-debug)
       workspaces:
@@ -117,7 +118,7 @@ spec:
         - name: properties-file
           value: ""
         - name: directory-name
-          value: "."
+          value: $(params.skit-name)
         - name: pipeline-debug
           value: $(params.pipeline-debug)
       workspaces:
@@ -140,7 +141,7 @@ spec:
         - name: pipeline-debug
           value: $(params.pipeline-debug)
         - name: directory-name
-          value: "."
+          value: $(params.skit-name)
         - name: commit-timestamp
           value: ""
     - name: code-vulnerability-scan
@@ -186,7 +187,7 @@ spec:
         - name: commit-id
           value: $(tasks.skit-git-clone.results.git-commit)
         - name: directory-name
-          value: $(params.cf-app)
+          value: $(params.skit-name)
         - name: scm-type
           value: $(params.scm-type)
         - name: project-id

--- a/.pipeline/cf/pipeline.yaml
+++ b/.pipeline/cf/pipeline.yaml
@@ -95,7 +95,7 @@ spec:
         - name: properties-file
           value: "build.properties"
         - name: directory-name
-          value: $(params.skit-name)
+          value: ""
         - name: pipeline-debug
           value: $(params.pipeline-debug)
       workspaces:

--- a/.pipeline/cf/pipeline.yaml
+++ b/.pipeline/cf/pipeline.yaml
@@ -117,7 +117,7 @@ spec:
         - name: properties-file
           value: ""
         - name: directory-name
-          value: ""
+          value: $(SKIT_NAME)
         - name: pipeline-debug
           value: $(params.pipeline-debug)
       workspaces:
@@ -140,7 +140,7 @@ spec:
         - name: pipeline-debug
           value: $(params.pipeline-debug)
         - name: directory-name
-          value: ""
+          value: $(SKIT_NAME)
         - name: commit-timestamp
           value: ""
     - name: code-vulnerability-scan
@@ -186,7 +186,7 @@ spec:
         - name: commit-id
           value: $(tasks.skit-git-clone.results.git-commit)
         - name: directory-name
-          value: ""
+          value: $(SKIT_NAME)
         - name: scm-type
           value: $(params.scm-type)
         - name: project-id

--- a/.pipeline/cf/pipeline.yaml
+++ b/.pipeline/cf/pipeline.yaml
@@ -38,7 +38,7 @@ spec:
       description: pr url
       default: ""
     - name: scm-type
-      value: "github"
+      default: "github"
     - name: project-id
       default: ""
     - name: devex-skit-assets-git

--- a/.pipeline/cf/pipeline.yaml
+++ b/.pipeline/cf/pipeline.yaml
@@ -141,6 +141,8 @@ spec:
           value: $(params.pipeline-debug)
         - name: directory-name
           value: ""
+        - name: commit-timestamp
+          value: ""
     - name: code-vulnerability-scan
       runAfter:
         - cra-discovery-scan

--- a/.pipeline/cf/pipeline.yaml
+++ b/.pipeline/cf/pipeline.yaml
@@ -36,8 +36,9 @@ spec:
       description: the repo URL of the skit repo
     - name: pr-url
       description: pr url
-    - name: commit-timestamp
+      default: ""
     - name: scm-type
+      value: "github"
     - name: project-id
       default: ""
     - name: devex-skit-assets-git
@@ -140,8 +141,6 @@ spec:
           value: $(params.pipeline-debug)
         - name: directory-name
           value: ""
-        - name: commit-timestamp
-          value: $(params.commit-timestamp)
     - name: code-vulnerability-scan
       runAfter:
         - cra-discovery-scan

--- a/.pipeline/cf/pipeline.yaml
+++ b/.pipeline/cf/pipeline.yaml
@@ -116,8 +116,104 @@ spec:
       workspaces:
         - name: output
           workspace: pipeline-ws
-    - name: build
+    - name: cra-discovery-scan
       runAfter: [skit-git-clone, assets-git-clone]
+      taskRef:
+        name: cra-discovery
+      workspaces:
+        - name: artifacts
+          workspace: pipeline-ws
+      params:
+        - name: repository
+          value: $(tasks.extract-repository-url.results.extracted-value)
+        - name: revision
+          value: $(params.branch)
+        - name: commit-id
+          value: $(tasks.clone-task.results.git-commit)
+        - name: pipeline-debug
+          value: $(params.pipeline-debug)
+        - name: directory-name
+          value: ""
+        - name: commit-timestamp
+          value: $(params.commit-timestamp)
+    - name: code-vulnerability-scan
+      runAfter:
+        - cra-discovery-scan
+      taskRef:
+        name: cra-vulnerability-remediation
+      workspaces:
+        - name: artifacts
+          workspace: pipeline-ws
+        - name: secrets
+          workspace: pipeline-ws
+      params:
+        - name: repository
+          value: $(tasks.extract-repository-url.results.extracted-value)
+        - name: revision
+          value: $(params.branch)
+        - name: pr-url
+          value: $(params.pr-url)
+        - name: commit-id
+          value: $(tasks.clone-task.results.git-commit)
+        - name: scm-type
+          value: $(params.scm-type)
+        - name: project-id
+          value: $(params.project-id) 
+    - name: cra-cis-check
+      taskRef:
+        name: cra-cis-check
+      runAfter:
+        - cra-discovery-scan
+      workspaces:
+        - name: secrets
+          workspace: pipeline-ws
+        - name: artifacts
+          workspace: pipeline-ws
+      params:
+        - name: repository
+          value: $(tasks.extract-repository-url.results.extracted-value)
+        - name: revision
+          value: $(params.branch)
+        - name: pr-url
+          value: $(params.pr-url)
+        - name: commit-id
+          value: $(tasks.clone-task.results.git-commit)
+        - name: directory-name
+          value: ""
+        - name: scm-type
+          value: $(params.scm-type)
+        - name: project-id
+          value: $(params.project-id)
+    - name: cra-bom
+      taskRef:
+        name: cra-bom
+      runAfter:
+        - cra-discovery-scan
+      workspaces:
+        - name: artifacts
+          workspace: pipeline-ws
+        - name: secrets
+          workspace: pipeline-ws          
+      params:
+        - name: repository
+          value: $(tasks.extract-repository-url.results.extracted-value)
+        - name: revision
+          value: $(params.branch)
+        - name: pr-url
+          value: $(params.pr-url)
+        - name: commit-id
+          value: $(tasks.clone-task.results.git-commit)
+        - name: target-branch
+          value: $(params.branch)
+        - name: target-commit-id
+          value: $(tasks.clone-task.results.git-commit)      
+        - name: scm-type
+          value: $(params.scm-type)
+        - name: project-id
+          value: $(params.project-id)
+    - name: build
+      runAfter:
+        - cra-discovery-scan
       workspaces:
         - name: output
           workspace: pipeline-ws

--- a/.pipeline/helm/listener.yaml
+++ b/.pipeline/helm/listener.yaml
@@ -71,6 +71,8 @@ spec:
       description: the name of the directory containing the helm chart
     - name: DEPLOY_TARGET
       description: the deployment target
+    - name: APP_NAME
+      description: the name of the skit being monitored
     - name: SKIT_REG_ENDPOINT
       description: the skit registration endpoint URL
     - name: SKIT_REG_AUTH_TOKEN
@@ -166,6 +168,8 @@ spec:
             value: $(params.DEVX_SKIT_ASSETS_GIT_URL_RAW)
           - name: deploy-target
             value: $(params.DEPLOY_TARGET)
+          - name: skit-name
+            value: $(params.APP_NAME)
           - name: skit-reg-endpoint
             value: $(params.SKIT_REG_ENDPOINT)
           - name: skit-reg-auth-token

--- a/.pipeline/helm/listener.yaml
+++ b/.pipeline/helm/listener.yaml
@@ -71,7 +71,7 @@ spec:
       description: the name of the directory containing the helm chart
     - name: DEPLOY_TARGET
       description: the deployment target
-    - name: APP_NAME
+    - name: app-name
       description: the name of the skit being monitored
     - name: SKIT_REG_ENDPOINT
       description: the skit registration endpoint URL
@@ -169,7 +169,7 @@ spec:
           - name: deploy-target
             value: $(params.DEPLOY_TARGET)
           - name: skit-name
-            value: $(params.APP_NAME)
+            value: $(params.app-name)
           - name: skit-reg-endpoint
             value: $(params.SKIT_REG_ENDPOINT)
           - name: skit-reg-auth-token

--- a/.pipeline/helm/pipeline.yaml
+++ b/.pipeline/helm/pipeline.yaml
@@ -286,7 +286,7 @@ spec:
         - name: workspace
           workspace: pipeline-ws
     - name: build
-      runAfter: [skit-git-clone, assets-git-clone]
+      runAfter: [code-vulnerability-scan, cra-cis-check, cra-bom]
       taskRef:
         name: toolchain-build
       params:

--- a/.pipeline/helm/pipeline.yaml
+++ b/.pipeline/helm/pipeline.yaml
@@ -166,6 +166,101 @@ spec:
           value: $(tasks.skit-git-clone.results.git-branch)
         - name: git-commit
           value: $(tasks.skit-git-clone.results.git-commit)
+    - name: cra-discovery-scan
+      runAfter: [skit-git-clone, assets-git-clone]
+      taskRef:
+        name: cra-discovery
+      workspaces:
+        - name: artifacts
+          workspace: pipeline-ws
+      params:
+        - name: repository
+          value: $(tasks.extract-repository-url.results.extracted-value)
+        - name: revision
+          value: $(params.branch)
+        - name: commit-id
+          value: $(tasks.skit-git-clone.results.git-commit)
+        - name: pipeline-debug
+          value: $(params.pipeline-debug)
+        - name: directory-name
+          value: $(params.skit-name)
+        - name: commit-timestamp
+          value: ""
+    - name: code-vulnerability-scan
+      runAfter:
+        - cra-discovery-scan
+      taskRef:
+        name: cra-vulnerability-remediation
+      workspaces:
+        - name: artifacts
+          workspace: pipeline-ws
+        - name: secrets
+          workspace: pipeline-ws
+      params:
+        - name: repository
+          value: $(tasks.extract-repository-url.results.extracted-value)
+        - name: revision
+          value: $(params.branch)
+        - name: pr-url
+          value: $(params.pr-url)
+        - name: commit-id
+          value: $(tasks.skit-git-clone.results.git-commit)
+        - name: scm-type
+          value: $(params.scm-type)
+        - name: project-id
+          value: $(params.project-id) 
+    - name: cra-cis-check
+      taskRef:
+        name: cra-cis-check
+      runAfter:
+        - cra-discovery-scan
+      workspaces:
+        - name: secrets
+          workspace: pipeline-ws
+        - name: artifacts
+          workspace: pipeline-ws
+      params:
+        - name: repository
+          value: $(tasks.extract-repository-url.results.extracted-value)
+        - name: revision
+          value: $(params.branch)
+        - name: pr-url
+          value: $(params.pr-url)
+        - name: commit-id
+          value: $(tasks.skit-git-clone.results.git-commit)
+        - name: directory-name
+          value: $(params.skit-name)
+        - name: scm-type
+          value: $(params.scm-type)
+        - name: project-id
+          value: $(params.project-id)
+    - name: cra-bom
+      taskRef:
+        name: cra-bom
+      runAfter:
+        - cra-discovery-scan
+      workspaces:
+        - name: artifacts
+          workspace: pipeline-ws
+        - name: secrets
+          workspace: pipeline-ws          
+      params:
+        - name: repository
+          value: $(tasks.extract-repository-url.results.extracted-value)
+        - name: revision
+          value: $(params.branch)
+        - name: pr-url
+          value: $(params.pr-url)
+        - name: commit-id
+          value: $(tasks.skit-git-clone.results.git-commit)
+        - name: target-branch
+          value: $(params.branch)
+        - name: target-commit-id
+          value: $(tasks.skit-git-clone.results.git-commit)      
+        - name: scm-type
+          value: $(params.scm-type)
+        - name: project-id
+          value: $(params.project-id)
     - name: docker-lint
       runAfter: [skit-git-clone, assets-git-clone]
       taskRef:

--- a/.pipeline/helm/pipeline.yaml
+++ b/.pipeline/helm/pipeline.yaml
@@ -58,6 +58,13 @@ spec:
       default: ""
     - name: git-url
       description: the repo URL of the skit repo
+    - name: pr-url
+      description: pr url
+      default: ""
+    - name: scm-type
+      default: "github"
+    - name: project-id
+      default: ""
     - name: devex-skit-assets-git
       description: the org and repo containing skit assets
     - name: devex-skit-assets-git-release
@@ -70,6 +77,7 @@ spec:
       description: the repo URL used to download skit asset raw code
     - name: deploy-target
       description: the deployment target
+    - name: skit-name
     - name: skit-reg-endpoint
     - name: skit-reg-auth-token
     - name: devx-slack-channel-webhook


### PR DESCRIPTION
A few changes were needed to allow for CRA scanning to run on the skit monitoring pipelines:

- Add cra from tekton-catalog to pipeline definitions for both cf and helm
- Add DevOps Insight tile to the toolchain
- Read APP_NAME (for CF) and app-name (for helm) into props skit-name in order to get the repo name after cloning
- Added props pr-url, scm-type, and project-id and gave them defaults for cra task inputs

Changes:

- Made build runAfter the cfa tasks in order to cause a fail if those tasks fail