### PR TITLE
Making success check message not overflow and fix hanging pendings

### DIFF
--- a/.pipeline/pr/pipeline.yaml
+++ b/.pipeline/pr/pipeline.yaml
@@ -345,8 +345,6 @@ spec:
                 cat $SHUTTLE_PROPERTIES_FILE
             fi
 
-            echo "cf_status=failed" >> $SHUTTLE_PROPERTIES_FILE
-
             cd $SKIT_DIR
             # Push app
             if ! cf app "$CF_APP"; then  
@@ -697,8 +695,6 @@ spec:
           value: $(params.cluster-name)
         - name: setup-script
           value: |
-            echo "helm_status=failed" >> $SHUTTLE_PROPERTIES_FILE
-
             export CLUSTER_NAMESPACE="$(params.dev-cluster-namespace)"
             export CHART_PATH="$(params.helm-chart-path)"
             export HELM_UPGRADE_EXTRA_ARGS="$(params.helm-upgrade-extra-args)"

--- a/.pipeline/pr/pipeline.yaml
+++ b/.pipeline/pr/pipeline.yaml
@@ -347,6 +347,8 @@ spec:
                 cat $SHUTTLE_PROPERTIES_FILE
             fi
 
+            echo "cf-status=failed" >> $SHUTTLE_PROPERTIES_FILE
+
             cd $SKIT_DIR
             # Push app
             if ! cf app "$CF_APP"; then  
@@ -711,6 +713,8 @@ spec:
           value: $(params.cluster-name)
         - name: setup-script
           value: |
+            echot "helm-status=failed" >> $SHUTTLE_PROPERTIES_FILE
+
             export CLUSTER_NAMESPACE="$(params.dev-cluster-namespace)"
             export CHART_PATH="$(params.helm-chart-path)"
             export HELM_UPGRADE_EXTRA_ARGS="$(params.helm-upgrade-extra-args)"
@@ -910,8 +914,10 @@ spec:
           value: $(params.context-cf)
         - name: description
           value: "Test"
-        - name: state
-          value: '$([$(tasks.cf-skit-verify-alert-register.status) == "Succeeded"] && echo "Succeeded" || echo "Failed")'
+        - name: state-var
+          value: 'cf-status'
+        - name: build-properties
+          value: "/artifacts/build.properties"
         - name: pipeline-debug
           value: $(params.pipeline-debug)
     - name: set-pr-status-helm-finally
@@ -929,7 +935,9 @@ spec:
           value: $(params.context-helm)
         - name: description
           value: "Test"
-        - name: state
-          value: '$([$(tasks.helm-skit-verify-alert-register.status) == "Succeeded"] && echo "Succeeded" || echo "Failed")'
+        - name: state-var
+          value: 'helm-status'
+        - name: build-properties
+          value: "/artifacts/build.properties"
         - name: pipeline-debug
           value: $(params.pipeline-debug)

--- a/.pipeline/pr/pipeline.yaml
+++ b/.pipeline/pr/pipeline.yaml
@@ -628,7 +628,6 @@ spec:
           value: $(params.dockerfile)
         - name: docker-commands
           value: |
-            echo "helm_status=failed" >> $SHUTTLE_PROPERTIES_FILE
             # Minting image tag using format: BUILD_NUMBER-BRANCH-COMMIT_ID-TIMESTAMP
             # e.g. 3-master-50da6912-20181123114435
             # (use build number as first segment to allow image tag as a patch release name according to semantic versioning)
@@ -714,6 +713,8 @@ spec:
           value: $(params.cluster-name)
         - name: setup-script
           value: |
+            echo "helm_status=failed" >> $SHUTTLE_PROPERTIES_FILE
+
             export CLUSTER_NAMESPACE="$(params.dev-cluster-namespace)"
             export CHART_PATH="$(params.helm-chart-path)"
             export HELM_UPGRADE_EXTRA_ARGS="$(params.helm-upgrade-extra-args)"

--- a/.pipeline/pr/pipeline.yaml
+++ b/.pipeline/pr/pipeline.yaml
@@ -331,7 +331,6 @@ spec:
             export DEVX_SKIT_ASSETS_GIT_REPO_DIR="/artifacts/devex-skit-assets"
             export DEVX_SKIT_ASSETS_GIT_URL_RAW=$(params.devex-skit-assets-git-url-raw)
             source /artifacts/devex-skit-assets/scripts/copy_assets.sh
-            exit 1
         - name: cf-commands
           value: |
             #!/bin/bash

--- a/.pipeline/pr/pipeline.yaml
+++ b/.pipeline/pr/pipeline.yaml
@@ -915,7 +915,7 @@ spec:
         - name: description
           value: "Test"
         - name: state-var
-          value: 'cf-status'
+          value: 'cf_status'
         - name: build-properties
           value: "/artifacts/build.properties"
         - name: pipeline-debug

--- a/.pipeline/pr/pipeline.yaml
+++ b/.pipeline/pr/pipeline.yaml
@@ -365,7 +365,7 @@ spec:
               set -e
               trap rollback ERR
               cf rename "$CF_APP" "$OLD_CF_APP"
-              cf push "$CF_APP" -f ./manifest.yaml --hostname ${SKIT_NAME}-devx-monitored-pr
+              cf push "$CF_APP" -f ./manifest.yaml --hostname ${SKIT_NAME}-devx-pr
               cf delete "$OLD_CF_APP" -f
             fi
 
@@ -486,7 +486,7 @@ spec:
         - name: context
           value: $(params.context-cf)
         - name: description
-          value: "Passed experience test! View site at: $(tasks.cf-skit-verify-alert-register.results.app-url)"
+          value: "URL: $(tasks.cf-skit-verify-alert-register.results.app-url) Passed Experience Test!"
         - name: state
           value: "success"
         - name: pipeline-debug

--- a/.pipeline/pr/pipeline.yaml
+++ b/.pipeline/pr/pipeline.yaml
@@ -331,6 +331,7 @@ spec:
             export DEVX_SKIT_ASSETS_GIT_REPO_DIR="/artifacts/devex-skit-assets"
             export DEVX_SKIT_ASSETS_GIT_URL_RAW=$(params.devex-skit-assets-git-url-raw)
             source /artifacts/devex-skit-assets/scripts/copy_assets.sh
+            exit 1
         - name: cf-commands
           value: |
             #!/bin/bash

--- a/.pipeline/pr/pipeline.yaml
+++ b/.pipeline/pr/pipeline.yaml
@@ -484,7 +484,7 @@ spec:
         - name: revision
           value: $(params.pr-revision)
         - name: context
-          value: $(params.context-cf)
+          value: "cf-verification"
         - name: description
           value: "$(tasks.cf-skit-verify-alert-register.results.app-url) Passed Experience Test!"
         - name: state
@@ -582,7 +582,7 @@ spec:
         - name: artifacts
           workspace: pipeline-ws
     - name: containerize
-      runAfter: [publish-doi-code-test]
+      runAfter: [publish-doi-code-tests]
       taskRef:
         name: icr-execute-in-dind
       params:
@@ -875,7 +875,7 @@ spec:
         - name: revision
           value: $(params.pr-revision)
         - name: context
-          value: $(params.context-helm)
+          value: "helm-verification"
         - name: description
           value: "$(tasks.helm-skit-verify-alert-register.results.app-url) Passed Experience Test!"
         - name: state

--- a/.pipeline/pr/pipeline.yaml
+++ b/.pipeline/pr/pipeline.yaml
@@ -486,7 +486,7 @@ spec:
         - name: context
           value: $(params.context-cf)
         - name: description
-          value: "URL: $(tasks.cf-skit-verify-alert-register.results.app-url) Passed Experience Test!"
+          value: "$(tasks.cf-skit-verify-alert-register.results.app-url) Passed Experience Test!"
         - name: state
           value: "success"
         - name: pipeline-debug
@@ -889,8 +889,47 @@ spec:
         - name: context
           value: $(params.context-helm)
         - name: description
-          value: "URL: $(tasks.helm-skit-verify-alert-register.results.app-url) Passed Experience Test!"
+          value: "$(tasks.helm-skit-verify-alert-register.results.app-url) Passed Experience Test!"
         - name: state
           value: "success"
+        - name: pipeline-debug
+          value: $(params.pipeline-debug)
+  finally:
+    - name: set-pr-status-cf-finally
+      taskRef:
+        name: git-set-commit-status
+      workspaces:
+        - name: artifacts
+          workspace: pipeline-ws
+      params:
+        - name: repository
+          value: $(params.repository)
+        - name: revision
+          value: $(params.pr-revision)
+        - name: context
+          value: $(params.context-cf)
+        - name: description
+          value: "Test"
+        - name: state
+          value: '$([$(tasks.cf-skit-verify-alert-register.status) == "Succeeded"] && echo "Succeeded" || echo "Failed")'
+        - name: pipeline-debug
+          value: $(params.pipeline-debug)
+    - name: set-pr-status-helm-finally
+      taskRef:
+        name: git-set-commit-status
+      workspaces:
+        - name: artifacts
+          workspace: pipeline-ws
+      params:
+        - name: repository
+          value: $(params.repository)
+        - name: revision
+          value: $(params.pr-revision)
+        - name: context
+          value: $(params.context-helm)
+        - name: description
+          value: "Test"
+        - name: state
+          value: '$([$(tasks.helm-skit-verify-alert-register.status) == "Succeeded"] && echo "Succeeded" || echo "Failed")'
         - name: pipeline-debug
           value: $(params.pipeline-debug)

--- a/.pipeline/pr/pipeline.yaml
+++ b/.pipeline/pr/pipeline.yaml
@@ -347,7 +347,7 @@ spec:
                 cat $SHUTTLE_PROPERTIES_FILE
             fi
 
-            echo "cf-status=failed" >> $SHUTTLE_PROPERTIES_FILE
+            echo "cf_status=failed" >> $SHUTTLE_PROPERTIES_FILE
 
             cd $SKIT_DIR
             # Push app
@@ -628,6 +628,7 @@ spec:
           value: $(params.dockerfile)
         - name: docker-commands
           value: |
+            echo "helm_status=failed" >> $SHUTTLE_PROPERTIES_FILE
             # Minting image tag using format: BUILD_NUMBER-BRANCH-COMMIT_ID-TIMESTAMP
             # e.g. 3-master-50da6912-20181123114435
             # (use build number as first segment to allow image tag as a patch release name according to semantic versioning)
@@ -713,8 +714,6 @@ spec:
           value: $(params.cluster-name)
         - name: setup-script
           value: |
-            echot "helm-status=failed" >> $SHUTTLE_PROPERTIES_FILE
-
             export CLUSTER_NAMESPACE="$(params.dev-cluster-namespace)"
             export CHART_PATH="$(params.helm-chart-path)"
             export HELM_UPGRADE_EXTRA_ARGS="$(params.helm-upgrade-extra-args)"
@@ -936,7 +935,7 @@ spec:
         - name: description
           value: "Test"
         - name: state-var
-          value: 'helm-status'
+          value: 'helm_status'
         - name: build-properties
           value: "/artifacts/build.properties"
         - name: pipeline-debug

--- a/.pipeline/pr/pipeline.yaml
+++ b/.pipeline/pr/pipeline.yaml
@@ -350,7 +350,7 @@ spec:
             cd $SKIT_DIR
             # Push app
             if ! cf app "$CF_APP"; then  
-              cf push "$CF_APP" -f ./manifest.yaml --hostname ${SKIT_NAME}-devx-monitored-pr
+              cf push "$CF_APP" -f ./manifest.yaml --hostname ${SKIT_NAME}-devx-pr
             else
               OLD_CF_APP="${CF_APP}-OLD-$(date +"%s")"
               rollback() {
@@ -889,7 +889,7 @@ spec:
         - name: context
           value: $(params.context-helm)
         - name: description
-          value: "Passed experience test! View site at: $(tasks.helm-skit-verify-alert-register.results.app-url)"
+          value: "URL: $(tasks.helm-skit-verify-alert-register.results.app-url) Passed Experience Test!"
         - name: state
           value: "success"
         - name: pipeline-debug

--- a/.pipeline/pr/pipeline.yaml
+++ b/.pipeline/pr/pipeline.yaml
@@ -111,16 +111,33 @@ spec:
     - name: docker-username
     - name: docker-password
     - name: context
-      default: "skit-monitoring"
-    - name: context-helm
-      default: "helm-verification"
-    - name: context-cf
-      default: "cf-verification"
+      default: "skit-monitoring-pl"
     - name: description
       default: "Testing the skit pipeline deploy automatically..."
+    - name: build-properties
+      default: "build.properties"
   workspaces:
     - name: pipeline-ws
   tasks:
+    - name: set-pr-status-pipeline-pending
+      taskRef:
+        name: git-set-commit-status
+      workspaces:
+        - name: artifacts
+          workspace: pipeline-ws
+      params:
+        - name: repository
+          value: $(params.repository)
+        - name: revision
+          value: $(params.pr-revision)
+        - name: context
+          value: $(params.context)
+        - name: description
+          value: "Pipeline is now running..."
+        - name: state
+          value: "pending"
+        - name: pipeline-debug
+          value: $(params.pipeline-debug)
     - name: skit-git-clone
       taskRef:
         name: git-clone-repo
@@ -138,7 +155,7 @@ spec:
         - name: revision
           value: $(params.pr-revision)
         - name: properties-file
-          value: "build.properties"
+          value: $(params.build-properties)
         - name: directory-name
           value: ""
         - name: pipeline-debug
@@ -276,43 +293,24 @@ spec:
           value: $(params.pipeline-debug)
         - name: custom-script
           value: |
+           echo "pl_status=failed" >> /artifacts/$(params.build-properties)
            if [[ -n $(find /artifacts -name pom.xml) ]]; then
             echo "Additional build required. Running Maven build."
             APP_NAME="$(params.skit-name)"
             cd /artifacts/$APP_NAME
             mvn -B package
            fi
-    - name: set-pr-status-cf-pending
+    - name: rolling-deploy-task
+      runAfter: [build]
       when:
         - input: $(params.enabled-cf)
           operator: in
           values: ["true"]
-      runAfter: [build]
-      taskRef:
-        name: git-set-commit-status
-      workspaces:
-        - name: artifacts
-          workspace: pipeline-ws
-      params:
-        - name: repository
-          value: $(params.repository)
-        - name: revision
-          value: $(params.pr-revision)
-        - name: context
-          value: $(params.context-cf)
-        - name: description
-          value: $(params.description)
-        - name: state
-          value: "pending"
-        - name: pipeline-debug
-          value: $(params.pipeline-debug)
-    - name: rolling-deploy-task
-      runAfter: [set-pr-status-cf-pending]
       taskRef:
         name: cf-deploy-app
       params:
         - name: shuttle-properties-file
-          value: "/artifacts/build.properties"
+          value: "/artifacts/$(params.build-properties)"
         - name: continuous-delivery-context-secret
           value: "secure-properties"
         - name: cloud-foundry-apikey-secret-key
@@ -427,7 +425,7 @@ spec:
       runAfter: [rolling-deploy-task]
       params:
         - name: shuttle-properties-file
-          value: "/artifacts/build.properties"
+          value: "/artifacts/$(params.build-properties)"
         - name: api-key
           value: $(params.api-key)
         - name: app-name
@@ -524,6 +522,10 @@ spec:
           value: $(tasks.skit-git-clone.results.git-commit)
     - name: docker-lint
       runAfter: [skit-git-clone, assets-git-clone]
+      when:
+        - input: $(params.enabled-helm)
+          operator: in
+          values: ["true"]
       taskRef:
         name: linter-docker-lint
       params:
@@ -579,32 +581,8 @@ spec:
       workspaces:
         - name: artifacts
           workspace: pipeline-ws
-    - name: set-pr-status-helm-pending
-      when:
-        - input: $(params.enabled-helm)
-          operator: in
-          values: ["true"]
-      runAfter: [build]
-      taskRef:
-        name: git-set-commit-status
-      workspaces:
-        - name: artifacts
-          workspace: pipeline-ws
-      params:
-        - name: repository
-          value: $(params.repository)
-        - name: revision
-          value: $(params.pr-revision)
-        - name: context
-          value: $(params.context-helm)
-        - name: description
-          value: $(params.description)
-        - name: state
-          value: "pending"
-        - name: pipeline-debug
-          value: $(params.pipeline-debug)
     - name: containerize
-      runAfter: [set-pr-status-helm-pending]
+      runAfter: [publish-doi-code-test]
       taskRef:
         name: icr-execute-in-dind
       params:
@@ -710,7 +688,7 @@ spec:
       runAfter: [vulnerability-advisor]
       params:
         - name: shuttle-properties-file
-          value: "/artifacts/build.properties"
+          value: "/artifacts/$(params.build-properties)"
         - name: cluster-region
           value: $(params.dev-region)
         - name: resource-group
@@ -805,7 +783,7 @@ spec:
       runAfter: [deploy-to-kubernetes]
       params:
         - name: shuttle-properties-file
-          value: "/artifacts/build.properties"
+          value: "/artifacts/$(params.build-properties)"
         - name: cluster-region
           value: $(params.dev-region)
         - name: resource-group
@@ -905,7 +883,7 @@ spec:
         - name: pipeline-debug
           value: $(params.pipeline-debug)
   finally:
-    - name: set-pr-status-cf-finally
+    - name: set-pr-status-pipeline-finally
       taskRef:
         name: git-set-commit-status
       workspaces:
@@ -917,33 +895,12 @@ spec:
         - name: revision
           value: $(params.pr-revision)
         - name: context
-          value: $(params.context-cf)
+          value: $(params.context)
         - name: description
-          value: "Test"
+          value: "Pipeline has finished running"
         - name: state-var
-          value: 'cf_status'
+          value: 'pl_status'
         - name: build-properties
-          value: "build.properties"
-        - name: pipeline-debug
-          value: $(params.pipeline-debug)
-    - name: set-pr-status-helm-finally
-      taskRef:
-        name: git-set-commit-status
-      workspaces:
-        - name: artifacts
-          workspace: pipeline-ws
-      params:
-        - name: repository
-          value: $(params.repository)
-        - name: revision
-          value: $(params.pr-revision)
-        - name: context
-          value: $(params.context-helm)
-        - name: description
-          value: "Test"
-        - name: state-var
-          value: 'helm_status'
-        - name: build-properties
-          value: "build.properties"
+          value: "$(params.build-properties)"
         - name: pipeline-debug
           value: $(params.pipeline-debug)

--- a/.pipeline/pr/pipeline.yaml
+++ b/.pipeline/pr/pipeline.yaml
@@ -917,7 +917,7 @@ spec:
         - name: state-var
           value: 'cf_status'
         - name: build-properties
-          value: "/artifacts/build.properties"
+          value: "build.properties"
         - name: pipeline-debug
           value: $(params.pipeline-debug)
     - name: set-pr-status-helm-finally
@@ -938,6 +938,6 @@ spec:
         - name: state-var
           value: 'helm_status'
         - name: build-properties
-          value: "/artifacts/build.properties"
+          value: "build.properties"
         - name: pipeline-debug
           value: $(params.pipeline-debug)

--- a/tasks/skit-verify-alert-register/skit-verify-alert-register.yaml
+++ b/tasks/skit-verify-alert-register/skit-verify-alert-register.yaml
@@ -179,7 +179,24 @@ spec:
         # Record task results
         if [ "$SHUTTLE_PROPERTIES_FILE" ]; then
           sed -ir "s/^[#]*\s*${DEPLOY_TARGET}_status=.*/${DEPLOY_TARGET}_status=success/" $SHUTTLE_PROPERTIES_FILE
+
+          if [ "${ENABLED_HELM}" == "true" ] && [ "${ENABLED_CF}" == "true" ]; then
+            if grep -q "cf_status=success" < $SHUTTLE_PROPERTIES_FILE && grep -q "helm_status=success" < $SHUTTLE_PROPERTIES_FILE; then
+              sed -ir "s/^[#]*\s*pl_status=.*/pl_status=success/" $SHUTTLE_PROPERTIES_FILE
+            fi
+          elif [ "${ENABLED_HELM}" == "true" ] && [ "${ENABLED_CF}" == "false" ]; then
+            if grep -q "helm_status=success" < $SHUTTLE_PROPERTIES_FILE; then
+              sed -ir "s/^[#]*\s*pl_status=.*/pl_status=success/" $SHUTTLE_PROPERTIES_FILE
+            fi
+          elif [ "${ENABLED_HELM}" == "false" ] && [ "${ENABLED_CF}" == "true" ]; then
+            if grep -q "cf_status=success" < $SHUTTLE_PROPERTIES_FILE; then
+              sed -ir "s/^[#]*\s*pl_status=.*/pl_status=success/" $SHUTTLE_PROPERTIES_FILE
+            fi
+          else
+            sed -ir "s/^[#]*\s*pl_status=.*/pl_status=success/" $SHUTTLE_PROPERTIES_FILE
+          fi
         fi
+        
 
         echo -n "$APP_URL" > $(results.app-url.path)
       volumeMounts:

--- a/tasks/skit-verify-alert-register/skit-verify-alert-register.yaml
+++ b/tasks/skit-verify-alert-register/skit-verify-alert-register.yaml
@@ -177,6 +177,10 @@ spec:
         source <(curl -sSL "$DEVX_SKIT_ASSETS_GIT_URL_RAW/scripts/verification_experience_test.sh")
 
         # Record task results
+        if [ "$SHUTTLE_PROPERTIES_FILE" ]; then
+          sed -ir "s/^[#]*\s*$(DEPLOY_TARGET)-status=.*/$(DEPLOY_TARGET)-status=success" $SHUTTLE_PROPERTIES_FILE
+        fi
+        
         echo -n "$APP_URL" > $(results.app-url.path)
       volumeMounts:
         - mountPath: /cd-config

--- a/tasks/skit-verify-alert-register/skit-verify-alert-register.yaml
+++ b/tasks/skit-verify-alert-register/skit-verify-alert-register.yaml
@@ -178,7 +178,7 @@ spec:
 
         # Record task results
         if [ "$SHUTTLE_PROPERTIES_FILE" ]; then
-          sed -ir "s/^[#]*\s*$(DEPLOY_TARGET)_status=.*/$(DEPLOY_TARGET)_status=success" $SHUTTLE_PROPERTIES_FILE
+          sed -ir "s/^[#]*\s*$(DEPLOY_TARGET)_status=.*/$(DEPLOY_TARGET)_status=success/" $SHUTTLE_PROPERTIES_FILE
         fi
 
         echo -n "$APP_URL" > $(results.app-url.path)

--- a/tasks/skit-verify-alert-register/skit-verify-alert-register.yaml
+++ b/tasks/skit-verify-alert-register/skit-verify-alert-register.yaml
@@ -178,7 +178,7 @@ spec:
 
         # Record task results
         if [ "$SHUTTLE_PROPERTIES_FILE" ]; then
-          sed -ir "s/^[#]*\s*$(DEPLOY_TARGET)_status=.*/$(DEPLOY_TARGET)_status=success/" $SHUTTLE_PROPERTIES_FILE
+          sed -ir "s/^[#]*\s*${DEPLOY_TARGET}_status=.*/${DEPLOY_TARGET}_status=success/" $SHUTTLE_PROPERTIES_FILE
         fi
 
         echo -n "$APP_URL" > $(results.app-url.path)

--- a/tasks/skit-verify-alert-register/skit-verify-alert-register.yaml
+++ b/tasks/skit-verify-alert-register/skit-verify-alert-register.yaml
@@ -178,9 +178,9 @@ spec:
 
         # Record task results
         if [ "$SHUTTLE_PROPERTIES_FILE" ]; then
-          sed -ir "s/^[#]*\s*$(DEPLOY_TARGET)-status=.*/$(DEPLOY_TARGET)-status=success" $SHUTTLE_PROPERTIES_FILE
+          sed -ir "s/^[#]*\s*$(DEPLOY_TARGET)_status=.*/$(DEPLOY_TARGET)_status=success" $SHUTTLE_PROPERTIES_FILE
         fi
-        
+
         echo -n "$APP_URL" > $(results.app-url.path)
       volumeMounts:
         - mountPath: /cd-config

--- a/tasks/skit-verify-alert-register/skit-verify-alert-register.yaml
+++ b/tasks/skit-verify-alert-register/skit-verify-alert-register.yaml
@@ -140,6 +140,10 @@ spec:
             cat $SHUTTLE_PROPERTIES_FILE
         fi
 
+        if ! grep -q "pl_status=" < $SHUTTLE_PROPERTIES_FILE
+          echo "pl_status=failed" >> $SHUTTLE_PROPERTIES_FILE
+        fi
+
         if [ "${DEPLOY_TARGET}" == "helm" ] || [ "${DEPLOY_TARGET}" == "both" ] && [ "${ENABLED_HELM}" == "false" ]; then
             echo "Helm pipeline is disabled for this toolchain"
             exit 0
@@ -178,7 +182,7 @@ spec:
 
         # Record task results
         if [ "$SHUTTLE_PROPERTIES_FILE" ]; then
-          sed -ir "s/^[#]*\s*${DEPLOY_TARGET}_status=.*/${DEPLOY_TARGET}_status=success/" $SHUTTLE_PROPERTIES_FILE
+          echo "${DEPLOY_TARGET}_status=success" >> $SHUTTLE_PROPERTIES_FILE
 
           if [ "${ENABLED_HELM}" == "true" ] && [ "${ENABLED_CF}" == "true" ]; then
             if grep -q "cf_status=success" < $SHUTTLE_PROPERTIES_FILE && grep -q "helm_status=success" < $SHUTTLE_PROPERTIES_FILE; then


### PR DESCRIPTION
Success message on PRs was so long that it was getting cut off and GH doesn't let you copy from the `hover for additional details (...)`

Additionally, when a pipeline failed, it would never set the status to failed, so I added a feature that if the pipeline does fail, most of the time it will set the pipeline state to failed. (Some edge cases, such as if the pipeline fails before build may cause the status to still hang as pending, due to implementation limitations