### PR TITLE
Health checks have not been running for helm

### DIFF
--- a/.pipeline/helm/pipeline.yaml
+++ b/.pipeline/helm/pipeline.yaml
@@ -543,6 +543,7 @@ spec:
         - name: setup-script
           value: |
             export CLUSTER_NAMESPACE="$(params.dev-cluster-namespace)"
+            export APP_URL=$HELM_APP_URL
         - name: script
           value: |
             # uncomment to debug the script

--- a/.pipeline/pr/pipeline.yaml
+++ b/.pipeline/pr/pipeline.yaml
@@ -789,6 +789,7 @@ spec:
         - name: setup-script
           value: |
             export CLUSTER_NAMESPACE="$(params.dev-cluster-namespace)"
+            export APP_URL=$HELM_APP_URL
         - name: script
           value: |
             # uncomment to debug the script


### PR DESCRIPTION
With a previous change from APP_URL to HELM_APP_URL in the pipeline, this caused health checks to silently not run. These changes should allow for APP_URL to be set for these tasks and get the required health check

See bottom of: https://cloud.ibm.com/devops/pipelines/tekton/5e8ca235-673d-47df-a0ca-79942bcdb07c/runs/1dce97a9-eb16-4689-bb52-fdc8d1ee612d/check-health/execute?env_id=ibm:yp:us-south