### PR TITLE
Promote to master

### DIFF
--- a/.bluemix/pipeline_tekton_cf.yml
+++ b/.bluemix/pipeline_tekton_cf.yml
@@ -35,6 +35,15 @@ triggers:
     name: manual-run
     eventListener: manual-run
     properties: []
+  - type: timer
+    name: cron-monitor
+    eventListener: manual-run
+    cron: "30 10 * * *"
+    timezone: "America/Chicago"
+    properties:
+      - name: branch
+        type: text
+        value: master
 properties:
   - type: text
     name: cf-app

--- a/.bluemix/pipeline_tekton_helm.yml
+++ b/.bluemix/pipeline_tekton_helm.yml
@@ -55,6 +55,15 @@ triggers:
     name: manual-run
     eventListener: manual-run
     properties: []
+  - type: timer
+    name: cron-monitor
+    eventListener: manual-run
+    cron: "30 10 * * *"
+    timezone: "America/Chicago"
+    properties:
+      - name: branch
+        type: text
+        value: master
 properties:
   - type: secure
     name: toolchain-apikey

--- a/.pipeline/helm/pipeline.yaml
+++ b/.pipeline/helm/pipeline.yaml
@@ -543,6 +543,7 @@ spec:
         - name: setup-script
           value: |
             export CLUSTER_NAMESPACE="$(params.dev-cluster-namespace)"
+            export APP_URL=$HELM_APP_URL
         - name: script
           value: |
             # uncomment to debug the script

--- a/.pipeline/pr/pipeline.yaml
+++ b/.pipeline/pr/pipeline.yaml
@@ -789,6 +789,7 @@ spec:
         - name: setup-script
           value: |
             export CLUSTER_NAMESPACE="$(params.dev-cluster-namespace)"
+            export APP_URL=$HELM_APP_URL
         - name: script
           value: |
             # uncomment to debug the script


### PR DESCRIPTION
* Health checks have not been running for helm

With a previous change from APP_URL to HELM_APP_URL in the pipeline, this caused health checks to silently not run. These changes should allow for APP_URL to be set for these tasks and get the required health check

* Fixed for helm pipeline as well