### PR TITLE
fix: helm service cleanup for java

### DIFF
--- a/tasks/skit-cleanup-helm/skit-cleanup-helm.yaml
+++ b/tasks/skit-cleanup-helm/skit-cleanup-helm.yaml
@@ -59,4 +59,8 @@ spec:
         echo "Deleting Helm deployment: $HELM_CHART_NAME..."
         kubectl delete deployment.apps/$HELM_CHART_NAME-deployment
         echo "Deleting Helm service: $HELM_CHART_NAME..."
-        kubectl delete service/$HELM_CHART_NAME-application-service
+        if [[ $HELM_CHART_NAME = java* ]]; then
+            kubectl delete service/$HELM_CHART_NAME-service
+        else
+            kubectl delete service/$HELM_CHART_NAME-application-service
+        fi


### PR DESCRIPTION
This PR will fix the helm service cleanup for the Java starters, since they do not have service names with the word "application" in them.